### PR TITLE
US2058144: fix broken test 1.6.1.4

### DIFF
--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(Enforcing|Permissive)/'
+    - '/^(Enforcing|Permissive)$/'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(Enforcing|Permissive)/'
+    - '/SELINUX=(Enforcing|Permissive)/i'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -68,7 +68,7 @@ file:
     path: /etc/selinux/config
     exists: true
     contents:
-    - '/SELINUX=(Enforcing|Permissive)/'
+    - '/SELINUX=(enforcing|permissive)/'
     meta:
       server: 1
       workstation: NA
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(Enforcing|Permissive)/'
+    - '/SELINUX=enforcing/'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -64,7 +64,7 @@ file:
       - AC-3
       - MP-2
   selinux_config:
-    title: 1.6.1.4 | Ensure the SELinux mode is not disabled| selinux_status config
+    title: 1.6.1.4 | Ensure the SELinux mode is not disabled | selinux_status config
     path: /etc/selinux/config
     exists: true
     contents:
@@ -86,11 +86,11 @@ file:
     {{ if .Vars.amzn2023cis_rule_1_6_1_4 }}
 command:
   selinux_config_running:
-    title: 1.6.1.4 | Ensure the SELinux mode is not disabled| selinux_status config
+    title: 1.6.1.4 | Ensure the SELinux mode is not disabled | selinux_status config
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=enforcing/'
+    - '/SELINUX=(Enforcing|Permissive)/'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -68,7 +68,7 @@ file:
     path: /etc/selinux/config
     exists: true
     contents:
-    - '/SELINUX=(enforcing|permissive)/i'
+    - '/SELINUX=(enforcing|permissive)/'
     meta:
       server: 1
       workstation: NA
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(enforcing|permissive)/i'
+    - '/SELINUX=(enforcing|permissive)/'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -68,7 +68,7 @@ file:
     path: /etc/selinux/config
     exists: true
     contents:
-    - '/SELINUX=(enforcing|permissive)/'
+    - '/SELINUX=(enforcing|permissive)/i'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(Enforcing|Permissive)/i'
+    - '/SELINUX=(enforcing|permissive)/i'
     meta:
       server: 1
       workstation: NA

--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -68,7 +68,7 @@ file:
     path: /etc/selinux/config
     exists: true
     contents:
-    - '/SELINUX=(enforcing|permissive)/'
+    - '/SELINUX=(Enforcing|Permissive)/'
     meta:
       server: 1
       workstation: NA
@@ -90,7 +90,7 @@ command:
     exec: getenforce
     exit-status: 0
     stdout:
-    - '/SELINUX=(enforcing|permissive)/'
+    - '/SELINUX=(Enforcing|Permissive)/'
     meta:
       server: 1
       workstation: NA


### PR DESCRIPTION
Test 1.6.1.4 was failing in the audit stage.  It appears the stdout search criteria was incorrect for the output being provided by the "getenforce" exec command.  This has been updated to reflect the possible outcomes of this command.

It is worth noting that it appears this secondary test may not be required as it seems to be doing the same test as 1.6.1.5